### PR TITLE
Reduce CPU utilization during data loading.

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -163,8 +163,8 @@ class DataCreator(nn.Module):
             torch.Tensor: neural network input data
             torch.Tensor: neural network labels
         """
-        data = torch.Tensor()
-        labels = torch.Tensor()
+        data = []
+        labels = []
         # Loop over batch and different starting points
         # For every starting point, we take the number of time_history points as training data
         # and the number of time future data as labels
@@ -175,9 +175,7 @@ class DataCreator(nn.Module):
             target_end_time = target_start_time + self.time_future
             l = dp[target_start_time:target_end_time]
 
-            data = torch.cat((data, d[None, :]), 0)
-            labels = torch.cat((labels, l[None, :]), 0)
+            data.append(d.unsqueeze(dim=0))
+            labels.append(l.unsqueeze(dim=0))
 
-        return data, labels
-
-
+        return torch.cat(data, dim=0), torch.cat(labels, dim=0)

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -174,7 +174,9 @@ def main(args: argparse):
         train_loader = DataLoader(train_dataset,
                                   batch_size=args.batch_size,
                                   shuffle=True,
-                                  num_workers=4)
+                                  num_workers=4,
+                                  persistent_workers=True,
+                                  pin_memory=True)
 
         valid_dataset = HDF5Dataset(valid_string,
                                     mode='valid',
@@ -185,7 +187,9 @@ def main(args: argparse):
         valid_loader = DataLoader(valid_dataset,
                                   batch_size=args.batch_size,
                                   shuffle=False,
-                                  num_workers=4)
+                                  num_workers=4,
+                                  persistent_workers=True,
+                                  pin_memory=True)
 
         test_dataset = HDF5Dataset(test_string,
                                    mode='test',
@@ -196,7 +200,9 @@ def main(args: argparse):
         test_loader = DataLoader(test_dataset,
                                  batch_size=args.batch_size,
                                  shuffle=False,
-                                 num_workers=4)
+                                 num_workers=4,
+                                 persistent_workers=True,
+                                 pin_memory=True)
     except:
         raise Exception("Datasets could not be loaded properly")
 


### PR DESCRIPTION
The data loading procedure is adapted in order to reduce the overall CPU load during execution. A brief comparison using the [default](https://github.com/brandstetter-johannes/LPSDA#produce-datasets-for-korteweg-de-vries-kdv-equation) dataset of the _Korteweg-de Vries_ equation was conducted. The command under investigation is
```bash
$ CUDA_VISIBLE_DEVICES=0 python3 experiments/train.py \
    --device=cuda \
    --experiment=KdV \
    --KdV_augmentation=1,1.0,0.4,0.1 \
    --train_samples=512 \
    --num_epochs=10
```
leading to the following timings (original implementation):
```bash
real    44m45.176s
user  4366m26.973s
sys    182m31.383s
```
After the corresponding modifications, the timings change to
```bash
real    15m00.047s
user   104m42.002s
sys      9m22.463s
```

showing a strong decrease in the overall CPU utilization (`user`), as well as in the total runtime (`real`). It has to be noted, that the timings only represent a single run for `10` epochs each, so repeated time measurements may vary a little.